### PR TITLE
Add missing import mapping for Ember.computed.uniqBy()

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ JSON data for [RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-j
 | `Ember.computed.sum`                  | `import { sum } from "@ember/object/computed"`                             |
 | `Ember.computed.union`                | `import { union } from "@ember/object/computed"`                           |
 | `Ember.computed.uniq`                 | `import { uniq } from "@ember/object/computed"`                            |
+| `Ember.computed.uniqBy`               | `import { uniqBy } from "@ember/object/computed"`                          |
 | `Ember.copy`                          | `import { copy } from "@ember/object/internals"`                           |
 | `Ember.create`                        | `import { create } from "@ember/polyfills"`                                |
 | `Ember.debug`                         | `import { debug } from "@ember/debug"`                                     |
@@ -270,6 +271,7 @@ JSON data for [RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-j
 | `import { sum } from "@ember/object/computed"`              | `Ember.computed.sum`              |
 | `import { union } from "@ember/object/computed"`            | `Ember.computed.union`            |
 | `import { uniq } from "@ember/object/computed"`             | `Ember.computed.uniq`             |
+| `import { uniqBy } from "@ember/object/computed"`           | `Ember.computed.uniqBy`           |
 | `import Evented from "@ember/object/evented"`               | `Ember.Evented`                   |
 | `import { on } from "@ember/object/evented"`                | `Ember.on`                        |
 | `import { addListener } from "@ember/object/events"`        | `Ember.addListener`               |

--- a/globals.json
+++ b/globals.json
@@ -54,6 +54,7 @@
   "computed.filterBy": ["@ember/object/computed", "filterBy"],
   "computed.filterProperty": ["@ember/object/computed", "filterProperty"],
   "computed.uniq": ["@ember/object/computed", "uniq"],
+  "computed.uniqBy": ["@ember/object/computed", "uniqBy"],
   "computed.union": ["@ember/object/computed", "union"],
   "computed.intersect": ["@ember/object/computed", "intersect"],
   "Evented": ["@ember/object/evented"],


### PR DESCRIPTION
Related to https://github.com/ember-cli/ember-cli-shims/pull/132 and resolving a small part of #12 

The import path for this one seems uncontroversial to me...