### PR TITLE
Add missing import mapping for Ember.String.isHtmlSafe()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ JSON data for [RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-j
 | `Ember.String.decamelize`             | `import { decamelize } from "@ember/string"`                               |
 | `Ember.String.fmt`                    | `import { fmt } from "@ember/string"`                                      |
 | `Ember.String.htmlSafe`               | `import { htmlSafe } from "@ember/string"`                                 |
+| `Ember.String.isHtmlSafe`             | `import { isHtmlSafe } from "@ember/string"`                               |
 | `Ember.String.loc`                    | `import { loc } from "@ember/string"`                                      |
 | `Ember.String.underscore`             | `import { underscore } from "@ember/string"`                               |
 | `Ember.String.w`                      | `import { w } from "@ember/string"`                                        |
@@ -336,6 +337,7 @@ JSON data for [RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-j
 | `import { decamelize } from "@ember/string"` | `Ember.String.decamelize` |
 | `import { fmt } from "@ember/string"`        | `Ember.String.fmt`        |
 | `import { htmlSafe } from "@ember/string"`   | `Ember.String.htmlSafe`   |
+| `import { isHtmlSafe } from "@ember/string"` | `Ember.String.isHtmlSafe` |
 | `import { loc } from "@ember/string"`        | `Ember.String.loc`        |
 | `import { underscore } from "@ember/string"` | `Ember.String.underscore` |
 | `import { w } from "@ember/string"`          | `Ember.String.w`          |

--- a/globals.json
+++ b/globals.json
@@ -124,6 +124,7 @@
   "String.decamelize": ["@ember/string", "decamelize"],
   "String.fmt": ["@ember/string", "fmt"],
   "String.htmlSafe": ["@ember/string", "htmlSafe"],
+  "String.isHtmlSafe": ["@ember/string", "isHtmlSafe"],
   "String.loc": ["@ember/string", "loc"],
   "String.underscore": ["@ember/string", "underscore"],
   "String.w": ["@ember/string", "w"],


### PR DESCRIPTION
Resolving a small part of #12 

The import path for this one seems uncontroversial to me...