### PR TITLE
Add more RSVP APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ JSON data for [RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-j
 | `Ember.PromiseProxyMixin`                | `import PromiseProxyMixin from "@ember/object/promise-proxy-mixin"`        |
 | `Ember.RSVP`                             | `import RSVP from "rsvp"`                                                  |
 | `Ember.RSVP.Promise`                     | `import { Promise } from "rsvp"`                                           |
+| `Ember.RSVP.all`                         | `import { all } from "rsvp"`                                               |
+| `Ember.RSVP.allSettled`                  | `import { allSettled } from "rsvp"`                                        |
+| `Ember.RSVP.defer`                       | `import { defer } from "rsvp"`                                             |
+| `Ember.RSVP.denodeify`                   | `import { denodeify } from "rsvp"`                                         |
+| `Ember.RSVP.filter`                      | `import { filter } from "rsvp"`                                            |
+| `Ember.RSVP.hash`                        | `import { hash } from "rsvp"`                                              |
+| `Ember.RSVP.hashSettled`                 | `import { hashSettled } from "rsvp"`                                       |
+| `Ember.RSVP.map`                         | `import { map } from "rsvp"`                                               |
+| `Ember.RSVP.off`                         | `import { off } from "rsvp"`                                               |
+| `Ember.RSVP.on`                          | `import { on } from "rsvp"`                                                |
+| `Ember.RSVP.race`                        | `import { race } from "rsvp"`                                              |
+| `Ember.RSVP.reject`                      | `import { reject } from "rsvp"`                                            |
+| `Ember.RSVP.resolve`                     | `import { resolve } from "rsvp"`                                           |
 | `Ember.Resolver`                         | `import Resolver from "@ember/application/resolver"`                       |
 | `Ember.Route`                            | `import Route from "@ember/routing/route"`                                 |
 | `Ember.Router`                           | `import Router from "@ember/routing/router"`                               |
@@ -415,10 +428,23 @@ JSON data for [RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-j
 | `import $ from "jquery"` | `Ember.$` |
 
 #### `rsvp`
-| Module                           | Global               |
-| ---                              | ---                  |
-| `import RSVP from "rsvp"`        | `Ember.RSVP`         |
-| `import { Promise } from "rsvp"` | `Ember.RSVP.Promise` |
+| Module                               | Global                   |
+| ---                                  | ---                      |
+| `import RSVP from "rsvp"`            | `Ember.RSVP`             |
+| `import { Promise } from "rsvp"`     | `Ember.RSVP.Promise`     |
+| `import { all } from "rsvp"`         | `Ember.RSVP.all`         |
+| `import { allSettled } from "rsvp"`  | `Ember.RSVP.allSettled`  |
+| `import { defer } from "rsvp"`       | `Ember.RSVP.defer`       |
+| `import { denodeify } from "rsvp"`   | `Ember.RSVP.denodeify`   |
+| `import { filter } from "rsvp"`      | `Ember.RSVP.filter`      |
+| `import { hash } from "rsvp"`        | `Ember.RSVP.hash`        |
+| `import { hashSettled } from "rsvp"` | `Ember.RSVP.hashSettled` |
+| `import { map } from "rsvp"`         | `Ember.RSVP.map`         |
+| `import { off } from "rsvp"`         | `Ember.RSVP.off`         |
+| `import { on } from "rsvp"`          | `Ember.RSVP.on`          |
+| `import { race } from "rsvp"`        | `Ember.RSVP.race`        |
+| `import { reject } from "rsvp"`      | `Ember.RSVP.reject`      |
+| `import { resolve } from "rsvp"`     | `Ember.RSVP.resolve`     |
 
 ### Scripts
 

--- a/globals.json
+++ b/globals.json
@@ -159,5 +159,18 @@
   "compare": ["@ember/utils", "compare"],
   "$": ["jquery"],
   "RSVP": ["rsvp"],
+  "RSVP.all": ["rsvp", "all"],
+  "RSVP.allSettled": ["rsvp", "allSettled"],
+  "RSVP.race": ["rsvp", "race"],
+  "RSVP.hash": ["rsvp", "hash"],
+  "RSVP.hashSettled": ["rsvp", "hashSettled"],
+  "RSVP.defer": ["rsvp", "defer"],
+  "RSVP.denodeify": ["rsvp", "denodeify"],
+  "RSVP.on": ["rsvp", "on"],
+  "RSVP.off": ["rsvp", "off"],
+  "RSVP.resolve": ["rsvp", "resolve"],
+  "RSVP.reject": ["rsvp", "reject"],
+  "RSVP.map": ["rsvp", "map"],
+  "RSVP.filter": ["rsvp", "filter"],
   "RSVP.Promise": ["rsvp", "Promise"]
 }


### PR DESCRIPTION
as suggested in https://github.com/ember-cli/ember-rfc176-data/pull/18#issuecomment-313853501

I've left `cast` out because it is essentially doing the same as `RSVP.resolve()` and `async` because I was afraid of creating keyword conflicts 🤔 

Resolves #13 