### PR TITLE
Fix for Ember.String.isHTMLSafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ JSON data for [RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-j
 | `Ember.String.decamelize`                | `import { decamelize } from "@ember/string"`                               |
 | `Ember.String.fmt`                       | `import { fmt } from "@ember/string"`                                      |
 | `Ember.String.htmlSafe`                  | `import { htmlSafe } from "@ember/string"`                                 |
-| `Ember.String.isHtmlSafe`                | `import { isHtmlSafe } from "@ember/string"`                               |
+| `Ember.String.isHTMLSafe`                | `import { isHTMLSafe } from "@ember/string"`                               |
 | `Ember.String.loc`                       | `import { loc } from "@ember/string"`                                      |
 | `Ember.String.underscore`                | `import { underscore } from "@ember/string"`                               |
 | `Ember.String.w`                         | `import { w } from "@ember/string"`                                        |
@@ -395,7 +395,7 @@ JSON data for [RFC #176](https://github.com/emberjs/rfcs/blob/master/text/0176-j
 | `import { decamelize } from "@ember/string"` | `Ember.String.decamelize` |
 | `import { fmt } from "@ember/string"`        | `Ember.String.fmt`        |
 | `import { htmlSafe } from "@ember/string"`   | `Ember.String.htmlSafe`   |
-| `import { isHtmlSafe } from "@ember/string"` | `Ember.String.isHtmlSafe` |
+| `import { isHTMLSafe } from "@ember/string"` | `Ember.String.isHTMLSafe` |
 | `import { loc } from "@ember/string"`        | `Ember.String.loc`        |
 | `import { underscore } from "@ember/string"` | `Ember.String.underscore` |
 | `import { w } from "@ember/string"`          | `Ember.String.w`          |

--- a/globals.json
+++ b/globals.json
@@ -139,7 +139,7 @@
   "String.decamelize": ["@ember/string", "decamelize"],
   "String.fmt": ["@ember/string", "fmt"],
   "String.htmlSafe": ["@ember/string", "htmlSafe"],
-  "String.isHtmlSafe": ["@ember/string", "isHtmlSafe"],
+  "String.isHTMLSafe": ["@ember/string", "isHTMLSafe"],
   "String.loc": ["@ember/string", "loc"],
   "String.underscore": ["@ember/string", "underscore"],
   "String.w": ["@ember/string", "w"],


### PR DESCRIPTION
Currently importing `isHtmlSafe` from `@ember/string` generates this code:

```js
var isHtmlSafe = Ember.String.isHtmlSafe;
```

But this results in `undefined` as the correct casing is `isHTMLSafe`