### PR TITLE
Change "Router" default export name to "EmberRouter"

### DIFF
--- a/globals.json
+++ b/globals.json
@@ -116,7 +116,7 @@
   "keys": ["@ember/polyfills", "keys"],
   "platform.hasPropertyAccessors": ["@ember/polyfills", "hasPropertyAccessors"],
   "Route": ["@ember/routing/route"],
-  "Router": ["@ember/routing/router"],
+  "Router": ["@ember/routing/router", null, "EmberRouter"],
   "run": ["@ember/runloop", "run"],
   "run.begin": ["@ember/runloop", "begin"],
   "run.bind": ["@ember/runloop", "bind"],


### PR DESCRIPTION
Currently the codemod will produce `let Router = Router.extend(...)` for a fresh Ember app which might work but doesn't look like clean code. This PR changes the default name for the export to `EmberRouter` so that the codemod will instead produce `let Router = EmberRouter.extend(...)`.