### PR TITLE
Change htmlSafe and isHTMLSafe import path

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -888,7 +888,7 @@
     }
   },
   {
-    "global": "Ember._Template.htmlSafe",
+    "global": "Ember.String.htmlSafe",
     "module": "@ember/template",
     "export": "htmlSafe",
     "deprecated": false
@@ -904,7 +904,7 @@
     }
   },
   {
-    "global": "Ember._Template.isHTMLSafe",
+    "global": "Ember.String.isHTMLSafe",
     "module": "@ember/template",
     "export": "isHTMLSafe",
     "deprecated": false

--- a/mappings.json
+++ b/mappings.json
@@ -881,11 +881,31 @@
     "global": "Ember.String.htmlSafe",
     "module": "@ember/string",
     "export": "htmlSafe",
+    "deprecated": true,
+    "replacement": {
+      "module": "@ember/template",
+      "export": "htmlSafe"
+    }
+  },
+  {
+    "global": "Ember._Template.htmlSafe",
+    "module": "@ember/template",
+    "export": "htmlSafe",
     "deprecated": false
   },
   {
     "global": "Ember.String.isHTMLSafe",
     "module": "@ember/string",
+    "export": "isHTMLSafe",
+    "deprecated": true,
+    "replacement": {
+      "module": "@ember/template",
+      "export": "isHTMLSafe"
+    }
+  },
+  {
+    "global": "Ember._Template.isHTMLSafe",
+    "module": "@ember/template",
     "export": "isHTMLSafe",
     "deprecated": false
   },


### PR DESCRIPTION
Deprecates importing it from `@ember/string` and adds the replacement
to `@ember/template`.