### PR TITLE
New field proposal.

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -879,6 +879,9 @@
   },
   {
     "global": "Ember.String.htmlSafe",
+    "versions": {
+      "ember-source": "< 2.18"
+    },
     "module": "@ember/string",
     "export": "htmlSafe",
     "deprecated": true,
@@ -889,12 +892,18 @@
   },
   {
     "global": "Ember.String.htmlSafe",
+    "versions": {
+      "ember-source": ">= 2.18"
+    },
     "module": "@ember/template",
     "export": "htmlSafe",
     "deprecated": false
   },
   {
-    "global": "Ember.String.isHTMLSafe",
+    "global": "Ember._Template.isHTMLSafe",
+    "versions": {
+      "ember-source": "< 2.18"
+    },
     "module": "@ember/string",
     "export": "isHTMLSafe",
     "deprecated": true,
@@ -904,7 +913,10 @@
     }
   },
   {
-    "global": "Ember.String.isHTMLSafe",
+    "global": "Ember._Template.isHTMLSafe",
+    "versions": {
+      "ember-source": ">= 2.18"
+    },
     "module": "@ember/template",
     "export": "isHTMLSafe",
     "deprecated": false


### PR DESCRIPTION
The proposed addition is a field named `versions` which
contains an object similar to `dependencies` in the `package.json`.
The project's dependencies would need to satisfy these restriction
for a mapping to be taken into account.

It might be more useful to provide not a simple JSON, but the already
filtered version (we could use a function or expose a js file that
does the hardwork for the user).