### PR TITLE
Use buildHelper as localName for Ember.Helper.helper

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -617,6 +617,7 @@
     "global": "Ember.Helper.helper",
     "module": "@ember/component/helper",
     "export": "helper",
+    "localName": "buildHelper",
     "deprecated": false
   },
   {


### PR DESCRIPTION
This change allows the ember-modules-codemod to generate transformed helper files
that `import { helper as buildHelper }`. This brings it
into alignment with the ember-module-migrator's output.

The related change in the module migrator is here: https://github.com/rwjblue/ember-module-migrator/pull/69

Importing the helper as buildHelper allows the module migrator to `export const helper = buildHelper(...`,
which is necessary to avoid an issue where incorrect `export const helper = helper(...` code was being generated.

The issue that motived the helper->buildHelper change is: https://github.com/emberjs/ember.js/issues/16361#issue-304106626