### PR TITLE
Add support for dependentKeyCompat.

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -435,6 +435,12 @@
     "deprecated": false
   },
   {
+    "global": "Ember._dependentKeyCompat",
+    "module": "@ember/object/compat",
+    "export": "dependentKeyCompat",
+    "deprecated": false
+  },
+  {
     "global": "Ember.ComputedProperty",
     "module": "@ember/object/computed",
     "export": "default",


### PR DESCRIPTION
This was introduced in [emberjs/rfcs#478](https://github.com/emberjs/rfcs/blob/master/text/0478-tracked-properties-updates.md#depending-on-native-getters) and is available in Ember 3.13.0-beta.1 and higher.