### PR TITLE
Update CI to run on Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '8'
+  - '10'
 
 script:
   - yarn lint


### PR DESCRIPTION
I'm seeing a bunch of dependabot PRs that seem to be failing because they bumped the minimum Node to v10. They don't seem to bring much benefit, but at the very least we should run the tests also on newer versions? Opening this up for discussion.