### PR TITLE
Add `import { cached } from '@glimmer/tracking'`

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -1180,9 +1180,9 @@
     "deprecated": false
   },
   {
-    "global": "Ember._memo",
+    "global": "Ember._cached",
     "module": "@glimmer/tracking",
-    "export": "memo",
+    "export": "cached",
     "deprecated": false
   },
   {

--- a/mappings.json
+++ b/mappings.json
@@ -1178,6 +1178,11 @@
     "module": "@glimmer/tracking",
     "export": "tracked",
     "deprecated": false
+  },  {
+    "global": "Ember._memo",
+    "module": "@glimmer/tracking",
+    "export": "memo",
+    "deprecated": false
   },
   {
     "global": "Ember._createCache",

--- a/mappings.json
+++ b/mappings.json
@@ -1178,7 +1178,8 @@
     "module": "@glimmer/tracking",
     "export": "tracked",
     "deprecated": false
-  },  {
+  },
+  {
     "global": "Ember._memo",
     "module": "@glimmer/tracking",
     "export": "memo",


### PR DESCRIPTION
This adds a mapping from `{ memo } from '@glimmer/tracking'` to `Ember._memo`.

This enables the [`ember-memo-decorator-polyfill`][polyfill] for [RFC 566 "@memo decorator"][rfc-566] to work without any [`patch-package`][patch-package] hackery.

If you don't want to accept this PR yet, because the RFC isn't even in FCP yet, we need to instruct users of the polyfill to either accept the `patch-package` hack, or we need to come up with an alternative soltuion. Any help would be appreciated then! 💝 

[polyfill]: https://github.com/ember-polyfills/ember-memo-decorator-polyfill
[rfc-566]: https://github.com/emberjs/rfcs/pull/566
[patch-package]: https://github.com/ds300/patch-package/issues