### PR TITLE
Add import paths for usage of template helpers and components within strict mode

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -143,6 +143,18 @@
     "deprecated": false
   },
   {
+    "global": "Ember._Input",
+    "module": "@ember/component",
+    "export": "Input",
+    "deprecated": false
+  },
+  {
+    "global": "Ember._TextArea",
+    "module": "@ember/component",
+    "export": "TextArea",
+    "deprecated": false
+  },
+  {
     "global": "Ember._getComponentTemplate",
     "module": "@ember/component",
     "export": "getComponentTemplate",
@@ -404,6 +416,12 @@
     "deprecated": false
   },
   {
+    "global": "Ember._on",
+    "module": "@ember/modifier",
+    "export": "on",
+    "deprecated": false
+  },
+  {
     "global": "Ember._helperManagerCapabilities",
     "module": "@ember/helper",
     "export": "capabilities",
@@ -419,6 +437,36 @@
     "global": "Ember._invokeHelper",
     "module": "@ember/helper",
     "export": "invokeHelper",
+    "deprecated": false
+  },
+  {
+    "global": "Ember._array",
+    "module": "@ember/helper",
+    "export": "array",
+    "deprecated": false
+  },
+  {
+    "global": "Ember._concat",
+    "module": "@ember/helper",
+    "export": "concat",
+    "deprecated": false
+  },
+  {
+    "global": "Ember._fn",
+    "module": "@ember/helper",
+    "export": "fn",
+    "deprecated": false
+  },
+  {
+    "global": "Ember._get",
+    "module": "@ember/helper",
+    "export": "get",
+    "deprecated": false
+  },
+  {
+    "global": "Ember._hash",
+    "module": "@ember/helper",
+    "export": "hash",
     "deprecated": false
   },
   {
@@ -875,6 +923,12 @@
     "module": "@ember/routing/link-component",
     "export": "default",
     "localName": "LinkComponent",
+    "deprecated": false
+  },
+  {
+    "global": "Ember.LinkComponent",
+    "module": "@ember/routing",
+    "export": "LinkTo",
     "deprecated": false
   },
   {

--- a/mappings.json
+++ b/mappings.json
@@ -151,7 +151,7 @@
   {
     "global": "Ember._TextArea",
     "module": "@ember/component",
-    "export": "TextArea",
+    "export": "Textarea",
     "deprecated": false
   },
   {


### PR DESCRIPTION
RFC: https://github.com/emberjs/rfcs/pull/496/files#diff-f1be2bfd87e50eff6f90cff8cf7ab910631693a7fa6bbc03bcae794824fd3a7eR472

Globals:
![image](https://user-images.githubusercontent.com/199018/111097933-e1dd0600-8518-11eb-8307-b996d242622d.png)
