### PR TITLE
Map `service` to `Ember.inject.service`

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -1075,6 +1075,12 @@
     "deprecated": false
   },
   {
+    "global": "Ember.inject.service",
+    "module": "@ember/service",
+    "export": "service",
+    "deprecated": false
+  },
+  {
     "global": "Ember.String.camelize",
     "module": "@ember/string",
     "export": "camelize",


### PR DESCRIPTION
RFC 752 introduced the `service` export which was released in Ember 4.1. I tried creating a polyfill for this import by renaming `service` to `inject` with a custom babel plugin, but that triggers errors in older Ember releases since this module mapping doesn't include that export yet.
