### PR TITLE
Add deprecate to @ember/debug

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -240,6 +240,12 @@
     "deprecated": false
   },
   {
+    "global": "Ember.deprecate",
+    "module": "@ember/debug",
+    "export": "deprecate",
+    "deprecated": false
+  },
+  {
     "global": "Ember.inspect",
     "module": "@ember/debug",
     "export": "inspect",


### PR DESCRIPTION
All the context here: https://github.com/babel/ember-cli-babel/issues/441

To test if this actually solves the above:
Repro of babel/ember-cli-babel#441: https://github.com/NullVoxPopuli/repo-repro-ember-cli-babel-441
- run yarn

_Separate Terminal_
- checkout this branch for ember-rfc176-data
- yarn
- yarn link

_Back in the other terminal_
- yarn link "ember-rfc176-data"
- `ember test`
See:

```
{"type":"error","text":"Uncaught ReferenceError: deprecate is not defined at http://localhost:7357/assets/my-app-test-deprecate.js, line 28\n","testContext":{}}
```

Which is actually no different from pre-this change. I need to pair this with seeing if `Ember.deprecate` exists. Stand by.

--- 

update, it does:
![image](https://user-images.githubusercontent.com/199018/163659943-b36d1461-9c57-4657-b420-d11e03a92e0f.png)


So... more debugging. sorry for the noise -- if anyone can convert this to draft before I finish debugging, that'd be much appreciate (also, why does github not allow me to do this to my own PRs?)