### PR TITLE
Add @ember/debug deprecate mapping

### DIFF
--- a/mappings.json
+++ b/mappings.json
@@ -234,6 +234,12 @@
     "deprecated": false
   },
   {
+    "global": "Ember.deprecate",
+    "module": "@ember/debug",
+    "export": "deprecate",
+    "deprecated": false
+  },
+  {
     "global": "Ember.debug",
     "module": "@ember/debug",
     "export": "debug",


### PR DESCRIPTION
This is required in order to build v2 addons importing `deprecate` in
ember-cli 3.24.x

Co-authored-by: Robert Jackson <rjackson@linkedin.com>
